### PR TITLE
Fix warning async_forward_entry_setup

### DIFF
--- a/custom_components/drivvo/__init__.py
+++ b/custom_components/drivvo/__init__.py
@@ -34,10 +34,8 @@ async def async_setup_entry(
         hass.data.setdefault(DOMAIN, {})
         hass.data[DOMAIN][entry.entry_id] = entry.data
 
-        for platform in PLATFORMS:
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-            )
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
     else:
         raise ConfigEntryAuthFailed("Invalid authentication")
     return True


### PR DESCRIPTION
Fixes: #36, #45 and #35
```
2025-03-03 00:42:33.067 WARNING (MainThread) [homeassistant.helpers.frame] Detected code that calls async_forward_entry_setup for integration drivvo with title: xxxxxxx@gmail.com and entry_id: 01JNCJCQMBCM5H8CYFTVGBVZ6T, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1, please report this issue
```